### PR TITLE
Remove GOV.UK breadcrumbs and header

### DIFF
--- a/app/views/start.html
+++ b/app/views/start.html
@@ -1,27 +1,5 @@
 {% extends "layouts/default.html" %}
 
-{% block header %}
-  {{ govukHeader() }}
-{% endblock %}
-
-{% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [{
-      text: "Home",
-      href: "https://www.gov.uk"
-    }, {
-      text: "Education, training and skills",
-      href: "https://www.gov.uk/education"
-    }, {
-      text: "Teaching and leadership",
-      href: "https://www.gov.uk/education/teaching-and-leadership"
-    }, {
-      text: "Teacher records",
-      href: "https://www.gov.uk/education/teacher-records"
-    }]
-  }) }}
-{% endblock %}
-
 {% set beforeYouStart %}
 ## Before you start
 


### PR DESCRIPTION
For now the start page is part of the service

![localhost_3000_start](https://user-images.githubusercontent.com/319055/153408423-93deb201-114b-425c-bfa8-372272e5fc12.png)

