### PR TITLE
Update GOVUK guidance content

### DIFF
--- a/app/assets/govuk-trn.html
+++ b/app/assets/govuk-trn.html
@@ -423,8 +423,7 @@
 
   <div class="govuk-grid-column-two-thirds">
 
-  <p class="gem-c-lead-paragraph">Find out what a teacher reference number (TRN) is, what it is for and how teachers can get a reminder of their TRN.</p>
-
+  <p class="gem-c-lead-paragraph">Find out what a teacher reference number (TRN) is, what it’s for and how teachers can find a lost TRN.</p>
   </div>
 </div>
 
@@ -472,7 +471,7 @@
 
         </li>
         <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-          <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" data-track-category="contentsClicked" data-track-action="content_item 2" data-track-label="#what-to-do-if-you-have-forgotten-your-trn" data-track-options="{&quot;dimension29&quot;:&quot;What to do if you have forgotten your TRN\n&quot;}" href="#what-to-do-if-you-have-forgotten-your-trn">What to do if you have forgotten your TRN
+          <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" data-track-category="contentsClicked" data-track-action="content_item 2" data-track-label="#what-to-do-if-you-have-forgotten-your-trn" data-track-options="{&quot;dimension29&quot;:&quot;What to do if you have forgotten your TRN\n&quot;}" href="#what-to-do-if-you-have-forgotten-your-trn">What to do if you’ve forgotten your TRN
 </a>
 
         </li>
@@ -498,7 +497,7 @@
 <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak">
 
           <div class="govspeak">
-<h2 id="what-is-a-teacher-reference-number-trn">What is a teacher reference number (<abbr title="teacher reference number">TRN</abbr>)</h2>
+<h2 id="what-is-a-teacher-reference-number-trn">What is a teacher reference number (<abbr title="teacher reference number">TRN</abbr>)?</h2>
 
 <p>A <abbr title="teacher reference number">TRN</abbr> is a 7 digit number that uniquely identifies you in the education sector in England.</p>
 
@@ -506,24 +505,31 @@
 
 <p>Your <abbr title="teacher reference number">TRN</abbr> is personal to you – only disclose your <abbr title="teacher reference number">TRN</abbr> to your employer or an official.</p>
 
-<h2 id="what-to-do-if-you-have-forgotten-your-trn">What to do if you have forgotten your <abbr title="teacher reference number">TRN</abbr>
+<h2 id="what-to-do-if-you-have-forgotten-your-trn">What to do if you’ve forgotten your <abbr title="teacher reference number">TRN</abbr>
 </h2>
 
-<p>If you have forgotten your <abbr title="teacher reference number">TRN</abbr>:</p>
+<p>If you’ve forgotten your <abbr title="teacher reference number">TRN</abbr>, you can:</p>
 
 <ol class="steps">
 <li>
 <p>check your payslip, pension statement or teacher training records – your TRN is usually on these documents</p>
 </li>
 <li>
-<p>you can find your TRN online or by phone if you have already been issued with a TRN</p>
+<p>use the Find a lost TRN service</p>
+</li>
+<li>
+<p>request a reminder by phone</p>
 </li>
 </ol>
 <hr>
 
-<h3 id="request-a-trn-reminder-by-email">Find your <abbr title="teacher reference number">TRN</abbr> online</h3>
+<h3 id="request-a-trn-reminder-by-email">Use the Find a lost TRN service</h3>
 
-<p>Make sure you have your National Insurance number ready.</p>
+<p>You’ll be asked for your name, date of birth and National Insurance number.</p>
+
+<p>If there’s a match, you’ll get your TRN straight away.</p>
+
+<p>If there’s no match, or you don’t have a National Insurance number, it might take up to 5 days to find your TRN.</p>
 
 <p>
   <a class="gem-c-button govuk-button govuk-button--start" role="button" href="/start"> Start now <svg class="govuk-button__start-icon govuk-!-display-none-print" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a>
@@ -531,10 +537,10 @@
 
 <hr>
 
-<h3 id="request-a-trn-reminder-by-phone">Find your <abbr title="teacher reference number">TRN</abbr> by phone</h3>
+<h3 id="request-a-trn-reminder-by-phone">Request a TRN reminder by phone</h3>
 
 <div role="note" aria-label="Information" class="application-notice info-notice">
-<p>Call the Teaching Regulation Agency on 020 7593 5394.</p>
+<p>Call the Teaching Regulation Agency on 020 7593 5394. <br />Lines are open Monday to Friday, 9am to 5pm (except public holidays)</p>
 </div>
 
 <p>Make sure you have your National Insurance number ready before you call.</p>
@@ -562,7 +568,7 @@
 
 <h2 id="what-a-trn-is-for">What a <abbr title="teacher reference number">TRN</abbr> is for</h2>
 
-<p>You need know your <abbr title="teacher reference number">TRN</abbr> to:</p>
+<p>You need to know your <abbr title="teacher reference number">TRN</abbr> to:</p>
 
 <ul>
   <li>view your record with the Teaching Regulation Agency (<abbr title="Teaching Regulation Agency">TRA</abbr>), check your record is accurate and download professional certificates in the <a rel="external" href="https://teacherservices.education.gov.uk/SelfService/Login?_ga=2.262264459.647366995.1606732570-1146126761.1565606320" class="govuk-link">Teacher self service portal</a>
@@ -631,17 +637,6 @@
 </nav>
 
   </div>
-
-
-
-
-
-<div class="gem-c-contextual-sidebar__brexit-cta">
-  <h2 class="gem-c-contextual-sidebar__brexit-heading govuk-heading-s">Brexit</h2>
-  <p class="gem-c-contextual-sidebar__brexit-text govuk-body">
-    <a class="govuk-link" data-module="gem-track-click" data-track-category="relatedLinkClicked" data-track-action="1.0 Transition" data-track-label="/brexit" data-track-dimension="Check what you need to do" data-track-dimension-index="29" lang="en" data-savepage-href="/brexit" href="https://www.gov.uk/brexit">Check what you need to do</a>
-</p>
-</div>
 </div>
 
 </div>


### PR DESCRIPTION
Based on https://docs.google.com/document/d/1AXG01yBP2pA_z_p-fgIO7ZqCd3IzsJYM06zcvK34feY/edit

A local version of https://www.gov.uk/guidance/teacher-reference-number-trn