### PR TITLE
Move API down state onto it's own page

### DIFF
--- a/app/views/longer-than-normal.html
+++ b/app/views/longer-than-normal.html
@@ -1,5 +1,5 @@
 {% extends "layouts/wizard.html" %}
-{% set title = "It’s taking longer than usual for us to match TRNs" %}
+{% set title = "It’s taking us longer than usual to find TRNs" %}
 
 {% block beforeForm %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>

--- a/app/views/longer-than-normal.html
+++ b/app/views/longer-than-normal.html
@@ -1,0 +1,13 @@
+{% extends "layouts/wizard.html" %}
+{% set title = "It’s taking longer than usual for us to match TRNs" %}
+
+{% block beforeForm %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <p>If you give us all the information we need, you won’t get a response straight away. And if the information you give is incomplete, it might take more than five days to get back to you.</p>
+
+  <h2 class="govuk-heading-m">If you need your TRN urgently</h2>
+  <p>Call the Teaching Regulation Agency, and have your National Insurance number ready:</p>
+  {% include '_phone-line.html' %}
+
+  <div class="govuk-!-margin-bottom-6"></div>
+{% endblock %}

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -18,12 +18,6 @@ Your TRN may be shown on a:
 The TRN has previously been known as a QTS, GTC, DfE, DfES and DCSF number.
 {% endset %}
 
-{% set urgentTrn %}
-  <h2 class="govuk-heading-m">If you need your TRN urgently</h2>
-  <p>Call the Teaching Regulation Agency, and have your National Insurance number ready:</p>
-  {% include '_phone-line.html' %}
-{% endset %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -32,30 +26,11 @@ The TRN has previously been known as a QTS, GTC, DfE, DfES and DCSF number.
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if data.features.apiUnavailable.on %}
-        {% set html %}
-          <p class="govuk-notification-banner__heading">
-            It’s taking longer than usual to find TRNs
-          </p>
-          <p>
-            If you give us all the information we need, you won’t get a response straight away. And if the information you give is incomplete, it might take more than five days to get back to you.
-          </p>
-        {% endset %}
-        {{ govukNotificationBanner({
-          html: html,
-          classes: 'govuk-!-margin-bottom-4'
-        }) }}
-      {% endif %}
-
       <p body="govuk-body">Use this service to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>find your <a href="https://www.gov.uk/guidance/teacher-reference-number-trn" class="govuk-link">teacher reference number (TRN)</a> if you do not know it or have forgotten it</li>
         <li>check if you have a TRN</li>
       </ul>
-
-      {% if data.features.apiUnavailable.on %}
-        {{ urgentTrn | safe }}
-      {% endif %}
 
       {{ beforeYouStart | govukMarkdown | safe }}
 
@@ -68,7 +43,10 @@ The TRN has previously been known as a QTS, GTC, DfE, DfES and DCSF number.
 
       {{ otherWaysToFindOutYourTrn | govukMarkdown | safe }}
 
-      {{ urgentTrn | safe if not data.features.apiUnavailable.on }}
+      <h2 class="govuk-heading-m">If you need your TRN urgently</h2>
+
+      <p>Call the Teaching Regulation Agency, and have your National Insurance number ready:</p>
+      {% include '_phone-line.html' %}
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/wizards/find-a-lost-trn.js
+++ b/app/wizards/find-a-lost-trn.js
@@ -9,6 +9,7 @@ export default (req) => {
       '/you-dont-have-a-trn': { data: 'do-you-have-a-trn', value: 'No' }
     },
     '/ask-questions': {},
+    ...data.features.apiUnavailable.on && { '/longer-than-normal': {} },
     '/name': {},
     '/dob': {},
     '/have-nino': {


### PR DESCRIPTION
- Avoid banner blindness
- Avoid banner hiding the service context
- Tweaks title to say that it's _us_ that's taking longer

| Before | After |
|--|--|
| ![Screenshot 2022-02-25 at 15 07 41](https://user-images.githubusercontent.com/319055/155740074-e5e2efe3-41e5-4014-82f9-571466e89f1f.png) | ![Screenshot 2022-02-25 at 15 17 25](https://user-images.githubusercontent.com/319055/155740125-92ea9c1f-53c0-405e-ac73-0d65ebf66b7e.png) |

