### PR TITLE
Add shortcuts for user research

### DIFF
--- a/app/routes/user-research.js
+++ b/app/routes/user-research.js
@@ -4,7 +4,10 @@ export const userResearch = router => {
     const data = req.session.data
     data.successfulJourney = true
     data.features.apiUnavailable.on = false
-    res.redirect('/start')
+
+    // Shortcut to the check answers page if they've been through the journey
+    // once before
+    data['full-name'] ? res.redirect('/check-answers') : res.redirect('/start')
   })
 
   // Failure
@@ -12,7 +15,10 @@ export const userResearch = router => {
     const data = req.session.data
     data.successfulJourney = false
     data.features.apiUnavailable.on = false
-    res.redirect('/start')
+
+    // Shortcut to the check answers page if they've been through the journey
+    // once before
+    data['full-name'] ? res.redirect('/check-answers') : res.redirect('/start')
   })
 
   // API unavailable

--- a/app/routes/user-research.js
+++ b/app/routes/user-research.js
@@ -2,6 +2,7 @@ export const userResearch = router => {
   // Success
   router.get('/user-research/scenario-s/', (req, res) => {
     const data = req.session.data
+    data.scenario = 's'
     data.successfulJourney = true
     data.features.apiUnavailable.on = false
 
@@ -13,6 +14,7 @@ export const userResearch = router => {
   // Failure
   router.get('/user-research/scenario-f/', (req, res) => {
     const data = req.session.data
+    data.scenario = 'f'
     data.successfulJourney = false
     data.features.apiUnavailable.on = false
 
@@ -24,6 +26,7 @@ export const userResearch = router => {
   // API unavailable
   router.get('/user-research/scenario-u/', (req, res) => {
     const data = req.session.data
+    data.scenario = 'u'
     data.successfulJourney = false
     data.features.apiUnavailable.on = true
     res.redirect('/start')

--- a/app/views/layouts/email.html
+++ b/app/views/layouts/email.html
@@ -6,7 +6,6 @@
 {% set title = subject %}
 {% block skipLink %}{% endblock %}
 {% block header %}{% endblock %}
-{% block footer %}{% endblock %}
 
 {% block bodyStart %}
   <div class="govuk-width-container app-email__metadata-container">
@@ -31,4 +30,14 @@
   {{ govukHeader({
     containerClasses: "app-email__header"
   }) }}
+{% endblock %}
+
+{% block footer %}
+  {% if data.scenario %}
+    <div class="govuk-width-container app-email__metadata-container">
+      <p>
+        <a href="/user-research">Return to User research</a>
+      </p>
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
- If users have been through once already, shortcut them back to the `Check answers` page
- Add a link back to the user research page from the bottom of an email page