### PR TITLE
Represent NINO and ITT answers on check answers

### DIFF
--- a/app/views/check-answers.html
+++ b/app/views/check-answers.html
@@ -77,15 +77,29 @@
       items: [{
         text: "Change",
         visuallyHiddenText: "National Insurance number",
-        href: "/ni-number"
+        href: "/nino"
       }]
     }
-  } if data['have-nino'] === 'Yes', {
+  } if data['have-nino'] !== 'No', {
+    key: {
+      text: "Do you have a National Insurance number?"
+    },
+    value: {
+      text: "No"
+    },
+    actions: {
+      items: [{
+        text: "Change",
+        visuallyHiddenText: "National Insurance number",
+        href: "/have-nino"
+      }]
+    }
+  } if data['have-nino'] === 'No', {
     key: {
       text: "Teacher training provider"
     },
     value: {
-      text:  data['itt-provider']
+      text: data['itt-provider'] if data['itt-provider'] else 'Not given'
     },
     actions: {
       items: [{
@@ -94,7 +108,21 @@
         href: "/itt-provider"
       }]
     }
-  } if data['itt-provider'] and data['has-done-itt'] === 'yes'
+  } if data['has-done-itt'] === 'Yes', {
+    key: {
+      text: "Have you been enrolled in initial teacher training in England or Wales?"
+    },
+    value: {
+      text: data['has-done-itt']
+    },
+    actions: {
+      items: [{
+        text: "Change",
+        visuallyHiddenText: "teacher training provider",
+        href: "/itt-provider"
+      }]
+    }
+  } if data['has-done-itt'] === 'No'
 ]}) }}
 {% endblock %}
 

--- a/app/views/itt-provider.html
+++ b/app/views/itt-provider.html
@@ -29,12 +29,10 @@
     items: [
       {
         text: "Yes",
-        value: 'yes',
         conditional: { html: ITTProviderNameHtml }
       },
       {
-        text: "No",
-        value: 'no'
+        text: "No"
       }
     ],
     decorate: "has-done-itt"


### PR DESCRIPTION
If I do not have a NINO – playback the ‘Do you have a NINO' question and link to the `have-nino` page

If I have not done ITT, also play that back

Previously we hid these values and they could not be edited.
In the build we were always showing 'Not given'

| Before | After |
|--|--|
| ![Screenshot 2022-03-03 at 15 43 33](https://user-images.githubusercontent.com/319055/156599234-1c047c05-6b3f-4e51-b565-3617b415dd7d.png) | ![Screenshot 2022-03-03 at 15 43 18](https://user-images.githubusercontent.com/319055/156599244-0e3c3bf8-0f2f-45d9-8833-04aad178cef2.png) |



