### PR TITLE
Make the journey for TRN and non-TRN users the same (when TRN is not required)

### DIFF
--- a/app/data.js
+++ b/app/data.js
@@ -15,7 +15,7 @@ export default {
       description: 'Disable any functionality that requires a backend data lookup'
     },
     trnRequired: {
-      on: true,
+      on: false,
       name: 'TRN required when checking records',
       description: 'Allow only users with a TRN to check their records'
     },

--- a/app/routes/account.js
+++ b/app/routes/account.js
@@ -8,7 +8,7 @@ export const accountRoutes = router => {
     next()
   })
 
-  router.post('/account/name', (req, res, next) => {
+  router.post(['/account/name', '/account/official-name'], (req, res, next) => {
     const data = req.session.data
     if (!data.features.fullName.on) {
       req.session.data['full-name'] = `${req.body['first-name']} ${req.body['last-name']}`

--- a/app/views/_check-answers.html
+++ b/app/views/_check-answers.html
@@ -19,20 +19,6 @@
       } if change
     }, {
       key: {
-        text: "Use your email address to sign in?"
-      },
-      value: {
-        text: "Yes" if data.account['next-time'] !== "no" else "No"
-      },
-      actions: {
-        items: [{
-          text: "Change",
-          visuallyHiddenText: "if you want to use your email to sign in",
-          href: basePath + "/next-time"
-        }]
-      } if change
-    } if accountJourney and change, {
-      key: {
         text: "Do you have a TRN?"
       },
       value: {
@@ -199,6 +185,21 @@
           href: basePath + "/sms"
         }]
       } if change
-    } if findTRNJourney and data.features.sms.on
+    } if findTRNJourney and data.features.sms.on,
+    {
+      key: {
+        text: "Use your email address to sign in?"
+      },
+      value: {
+        text: "Yes" if data.account['next-time'] !== "no" else "No"
+      },
+      actions: {
+        items: [{
+          text: "Change",
+          visuallyHiddenText: "if you want to use your email to sign in",
+          href: basePath + "/next-time"
+        }]
+      } if change
+    } if accountJourney and change
   ]
 }) }}

--- a/app/views/_check-answers.html
+++ b/app/views/_check-answers.html
@@ -70,7 +70,7 @@
         items: [{
           text: "Change",
           visuallyHiddenText: "name",
-          href: basePath + "/name"
+          href: basePath + "/official-name" if accountJourney else basePath + "/name"
         }]
       } if change
     } if data['full-name'], {
@@ -84,10 +84,10 @@
         items: [{
           text: "Change",
           visuallyHiddenText: "previous name",
-          href: basePath + "/name"
+          href: basePath + "/official-name" if accountJourney else basePath + "/name"
         }]
       } if change
-    } if data['previous-name'] and not data['previous-name'] === " ", {
+    } if data['previous-name'] and not (data['previous-name'] === " "), {
       key: {
         text: "Date of birth"
       },

--- a/app/views/_previous-name.html
+++ b/app/views/_previous-name.html
@@ -1,0 +1,56 @@
+{% set previousNameHtml %}
+  <h2 class="govuk-heading-m govuk-!-margin-top-4">What was your previous name?</h2>
+  <p>You don’t have to tell us your previous name, but it will help us identify you.</p>
+  <p>If we cannot match your current name against our records, we’ll try to match your previous name.</p>
+  <p>If you changed your name more than once, tell us your most recent previous name.</p>
+  {% if useFullName %}
+    {{ govukInput({
+      label: {
+        text: "Previous name"
+      },
+      decorate: 'previous-name'
+    }) }}
+  {% else %}
+    {{ govukInput({
+      label: {
+        text: "Previous first name (optional)",
+        classes: "govuk-label--s"
+      },
+      decorate: 'previous-first-name'
+    }) }}
+
+    {{ govukInput({
+      label: {
+        text: "Previous last name (optional)",
+        classes: "govuk-label--s"
+      },
+      decorate: 'previous-last-name'
+    }) }}
+  {% endif %}
+{% endset %}
+
+{{ govukRadios({
+  fieldset: {
+    legend: {
+      classes: "govuk-fieldset__legend--m",
+      text: "Have you ever changed your name?"
+    }
+  },
+  items: [
+    {
+      value: "no",
+      text: "No, I haven’t changed my name"
+    },
+    {
+      value: "changed-name",
+      text: "Yes, I changed my name",
+      conditional: {
+        html: previousNameHtml
+      }
+    },
+    {
+      text: "Prefer not to say"
+    }
+  ],
+  decorate: 'changed-name'
+}) }}

--- a/app/views/account/next-time.html
+++ b/app/views/account/next-time.html
@@ -15,10 +15,6 @@
   <li>download your NPQ certificates</li>
 </ul>
 
-<h2 class="govuk-heading-m">Do not use a work email address</h2>
-
-<p class="govuk-!-margin-bottom-6">Your email address must be one you will always have access to. You could lose access to a work email address if you changed jobs.</p>
-
 {{ govukRadios({
   fieldset: {
     legend: {

--- a/app/views/account/official-name.html
+++ b/app/views/account/official-name.html
@@ -1,12 +1,13 @@
 {% extends "layouts/wizard.html" %}
 {% set useFullName = data.features.fullName.on %}
-{% set checkingAgainstTRNRecord = findTRNJourney or data.features.trnRequired.on or data.account['do-you-have-a-trn'] === 'Yes' %}
 {% set title = "What’s your name?" %}
 
 {% block form %}
   {% set previousNameHtml %}
-    <h2 class="govuk-heading-m govuk-!-margin-top-4">Previous name</h2>
-    <p>If we cannot match your current name against TRA records, we’ll try to match your previous name.</p>
+    <h2 class="govuk-heading-m govuk-!-margin-top-4">What was your previous name?</h2>
+    <p>You don’t have to tell us your previous name, but it will help us identify you.</p>
+    <p>If we cannot match your current name against our records, we’ll try to match your previous name.</p>
+    <p>If you changed your name more than once, tell us your most recent previous name.</p>
     {% if useFullName %}
       {{ govukInput({
         label: {
@@ -17,7 +18,7 @@
     {% else %}
       {{ govukInput({
         label: {
-          text: "Previous first name",
+          text: "Previous first name (optional)",
           classes: "govuk-label--s"
         },
         decorate: 'previous-first-name'
@@ -25,7 +26,7 @@
 
       {{ govukInput({
         label: {
-          text: "Previous last name",
+          text: "Previous last name (optional)",
           classes: "govuk-label--s"
         },
         decorate: 'previous-last-name'
@@ -38,7 +39,7 @@
   <h2 class="govuk-heading-m">Use the name on your official documents</h2>
   <p>
     You should tell us the name that appears on your passport, driving licence or marriage certificate, if you have one.
-    We’ll match it against the Teaching Regulation Agency (TRA) records.
+    We’ll try to match it against our records.
   </p>
 
   <p>If the names on your documents are different, give us the most recent one.</p>
@@ -72,16 +73,29 @@
     }) }}
   {% endif %}
 
-  {% if checkingAgainstTRNRecord %}
-    {{ govukCheckboxes({
-      items: [
-        {
-          value: "changed-name",
-          text: "I’ve changed my name since I received my teacher reference number (TRN)",
-          conditional: { html: previousNameHtml }
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--m",
+        text: "Have you ever changed your name?"
+      }
+    },
+    items: [
+      {
+        value: "no",
+        text: "No, I haven’t changed my name"
+      },
+      {
+        value: "changed-name",
+        text: "Yes, I changed my name",
+        conditional: {
+          html: previousNameHtml
         }
-      ],
-      decorate: 'changed-name'
-    }) }}
-  {% endif %}
+      },
+      {
+        text: "Prefer not to say"
+      }
+    ],
+    decorate: 'account.changed-name'
+  }) }}
 {% endblock %}

--- a/app/views/account/official-name.html
+++ b/app/views/account/official-name.html
@@ -3,37 +3,6 @@
 {% set title = "What’s your name?" %}
 
 {% block form %}
-  {% set previousNameHtml %}
-    <h2 class="govuk-heading-m govuk-!-margin-top-4">What was your previous name?</h2>
-    <p>You don’t have to tell us your previous name, but it will help us identify you.</p>
-    <p>If we cannot match your current name against our records, we’ll try to match your previous name.</p>
-    <p>If you changed your name more than once, tell us your most recent previous name.</p>
-    {% if useFullName %}
-      {{ govukInput({
-        label: {
-          text: "Previous name"
-        },
-        decorate: 'previous-name'
-      }) }}
-    {% else %}
-      {{ govukInput({
-        label: {
-          text: "Previous first name (optional)",
-          classes: "govuk-label--s"
-        },
-        decorate: 'previous-first-name'
-      }) }}
-
-      {{ govukInput({
-        label: {
-          text: "Previous last name (optional)",
-          classes: "govuk-label--s"
-        },
-        decorate: 'previous-last-name'
-      }) }}
-    {% endif %}
-  {% endset %}
-
   <h1 class="govuk-heading-xl">{{ title }}</h1>
 
   <h2 class="govuk-heading-m">Use the name on your official documents</h2>
@@ -73,29 +42,5 @@
     }) }}
   {% endif %}
 
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        classes: "govuk-fieldset__legend--m",
-        text: "Have you ever changed your name?"
-      }
-    },
-    items: [
-      {
-        value: "no",
-        text: "No, I haven’t changed my name"
-      },
-      {
-        value: "changed-name",
-        text: "Yes, I changed my name",
-        conditional: {
-          html: previousNameHtml
-        }
-      },
-      {
-        text: "Prefer not to say"
-      }
-    ],
-    decorate: 'account.changed-name'
-  }) }}
+  {% include "../_previous-name.html" %}
 {% endblock %}

--- a/app/views/name.html
+++ b/app/views/name.html
@@ -1,39 +1,11 @@
 {% extends "layouts/wizard.html" %}
 {% set useFullName = data.features.fullName.on %}
-{% set checkingAgainstTRNRecord = findTRNJourney or data.features.trnRequired.on or data.account['do-you-have-a-trn'] === 'Yes' %}
 {% set title = "Your name" %}
 
 {% block form %}
-  {% set previousNameHtml %}
-    {% if useFullName %}
-      {{ govukInput({
-        label: {
-          text: "Previous name"
-        },
-        decorate: 'previous-name'
-      }) }}
-    {% else %}
-      {{ govukInput({
-        label: {
-          text: "Previous first name"
-        },
-        decorate: 'previous-first-name'
-      }) }}
-
-      {{ govukInput({
-        label: {
-          text: "Previous last name"
-        },
-        decorate: 'previous-last-name'
-      }) }}
-    {% endif %}
-  {% endset %}
-
   <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-  {% if checkingAgainstTRNRecord %}
-    <p>We’ll match your name against the Teaching Regulation Agency records.</p>
-  {% endif %}
+  <p>We’ll match your name against the Teaching Regulation Agency records.</p>
 
   {% if useFullName %}
     {{ govukInput({
@@ -61,16 +33,5 @@
     }) }}
   {% endif %}
 
-  {% if checkingAgainstTRNRecord %}
-    {{ govukCheckboxes({
-      items: [
-        {
-          value: "changed-name",
-          text: "I’ve changed my name since I received my TRN",
-          conditional: { html: previousNameHtml }
-        }
-      ],
-      decorate: 'changed-name'
-    }) }}
-  {% endif %}
+  {% include "../_previous-name.html" %}
 {% endblock %}

--- a/app/wizards/account.js
+++ b/app/wizards/account.js
@@ -8,7 +8,6 @@ function emailHasAccount (data) {
 export default (req) => {
   const data = req.session.data
   const trnRequired = data.features.trnRequired.on
-  const hasTrn = (data.account && data.account['do-you-have-a-trn'] === 'Yes') || trnRequired
 
   const journey = {
     '/account/email': {},
@@ -35,8 +34,7 @@ export default (req) => {
     },
     '/account/have-nino': {
       '/account/trn-known': () => trnRequired && data['have-nino'] === 'No',
-      '/account/have-qts': () => hasTrn && data['have-nino'] === 'No',
-      '/account/next-time': { data: 'have-nino', value: 'No' }
+      '/account/have-qts': { data: 'have-nino', value: 'No' }
     },
     '/account/nino': {
       '/account/next-time': () => userMatchesDQTRecord(data)
@@ -44,16 +42,10 @@ export default (req) => {
     ...trnRequired
       ? { '/account/trn-known': {} }
       : {},
-
-    // Only include QTS questions if user has a TRN
-    ...hasTrn
-      ? {
-        '/account/have-qts': {
-          '/account/next-time': { data: 'has-qts', value: 'No' }
-        },
-        '/account/how-qts': {}
-      }
-      : {},
+    '/account/have-qts': {
+      '/account/next-time': { data: 'has-qts', value: 'No' }
+    },
+    '/account/how-qts': {},
     '/account/next-time': {
       '/account/change-email': { data: 'account.next-time', value: 'different' }
     },


### PR DESCRIPTION
- Always ask for previous name so we can match against it
- Make answering previous name optional, and use inclusive language, explaining why we are asking
- Design based on Register to Vote
- Always ask about QTS – they say they don't have a TRN, but we want to try and avoid false negatives
- Other journey cleanups

<img width="768" alt="Screenshot 2022-07-15 at 17 43 03" src="https://user-images.githubusercontent.com/319055/179276860-5c296f3b-1dfd-4b3a-b994-8db1845fb15d.png">

