### PR TITLE
Remove the Next time page from the flow

### DIFF
--- a/app/data.js
+++ b/app/data.js
@@ -15,9 +15,14 @@ export default {
       description: 'Disable any functionality that requires a backend data lookup'
     },
     trnRequired: {
-      on: false,
+      on: true,
       name: 'TRN required when checking records',
       description: 'Allow only users with a TRN to check their records'
+    },
+    noMatchJourney: {
+      on: false,
+      name: 'Show the No match page',
+      description: 'Include the ‘no match’ page in the Get an identity journey'
     },
     ittAutocomplete: {
       on: true,

--- a/app/views/_check-answers.html
+++ b/app/views/_check-answers.html
@@ -57,11 +57,6 @@
       key: "Phone number" if sendingTextMessage else "Send TRN by text message",
       value: data['phone-number'] if sendingTextMessage else "No",
       href: basePath + "/sms" if change
-    } if findTRNJourney and data.features.sms.on,
-    {
-      key: "Use your email address to sign in?",
-      value: "Yes" if data.account['next-time'] !== "no" else "No",
-      href: basePath + "/next-time" if change
-    } if accountJourney and change
+    } if findTRNJourney and data.features.sms.on
   ])
 }) }}

--- a/app/views/account/finish.html
+++ b/app/views/account/finish.html
@@ -12,10 +12,8 @@
     <p>Thank you, we’ve finished checking our records.</p>
   {% endif %}
 
-  {% if data.account['next-time'] === 'yes' %}
-    <h2 class="govuk-heading-m">Next time</h2>
-    <p class="govuk-!-margin-bottom-6">Next time, you can skip these questions by signing in with your email address: <b>{{ data['email-address'] or "email@example.com" }}</b></p>
-  {% endif %}
+  <h2 class="govuk-heading-m">Next time</h2>
+  <p class="govuk-!-margin-bottom-6">Next time, you can skip these questions by signing in with your email address: <b>{{ data['email-address'] or "email@example.com" }}</b></p>
 
   <input type="hidden" name="account-data" value="{{ data | stringify }}">
 {% endblock %}

--- a/app/views/account/finish.html
+++ b/app/views/account/finish.html
@@ -5,7 +5,7 @@
 {% block form %}
   <h1 class="govuk-panel__title">{{ title }}</h1>
 
-  {% if not matched %}
+  {% if not matched and data.features.noMatchJourney.on %}
     <h2 class="govuk-heading-m">You can continue without a match</h2>
     <p>We will attempt to match your record again. If we cannot, someone might be in touch to ask for more information.</p>
   {% else %}

--- a/app/wizards/account.js
+++ b/app/wizards/account.js
@@ -9,6 +9,7 @@ export default (req) => {
   const data = req.session.data
   const trnRequired = data.features.trnRequired.on
   const hasTrn = (data.account && data.account['do-you-have-a-trn'] === 'Yes') || trnRequired
+  const noMatchJourney = data.features.noMatchJourney.on
 
   const journey = {
     '/account/email': {},
@@ -51,7 +52,7 @@ export default (req) => {
       '/account/change-email': { data: 'account.next-time', value: 'different' }
     },
     '/account/check-answers': {},
-    ...hasTrn
+    ...(hasTrn && noMatchJourney)
       ? {
         '/account/no-match': {
           '/account/check-answers': { data: 'account.try-again', value: 'yes' }

--- a/app/wizards/account.js
+++ b/app/wizards/account.js
@@ -32,25 +32,22 @@ export default (req) => {
       : {},
     '/account/official-name': {},
     '/account/dob': {
-      '/account/next-time': () => userMatchesDQTRecord(data)
+      '/account/check-answers': () => userMatchesDQTRecord(data)
     },
     '/account/have-nino': {
       '/account/trn-known': () => trnRequired && data['have-nino'] === 'No',
       '/account/have-qts': { data: 'have-nino', value: 'No' }
     },
     '/account/nino': {
-      '/account/next-time': () => userMatchesDQTRecord(data)
+      '/account/check-answers': () => userMatchesDQTRecord(data)
     },
     ...trnRequired
       ? { '/account/trn-known': {} }
       : {},
     '/account/have-qts': {
-      '/account/next-time': { data: 'has-qts', value: 'No' }
+      '/account/check-answers': { data: 'has-qts', value: 'No' }
     },
     '/account/how-qts': {},
-    '/account/next-time': {
-      '/account/change-email': { data: 'account.next-time', value: 'different' }
-    },
     '/account/check-answers': {},
     ...(hasTrn && noMatchJourney)
       ? {
@@ -60,14 +57,7 @@ export default (req) => {
       }
       : {},
     '/account/finish': {},
-    '/account/return-to-service': {},
-
-    // Change email account flow
-    '/account/change-email': {},
-    '/account/change-email-confirmation': {},
-    '/account/change-email-next-time-confirmation': {
-      '/account/check-answers': true
-    }
+    '/account/return-to-service': {}
   }
 
   return wizard(journey, req)


### PR DESCRIPTION
We are removing the choice about whether to use your email address to sign in again next time as it will not affect what information we store, which kind of makes it a hollow choice.

Also feature flags the no match journey

https://trello.com/c/GMH6OOws/598-stop-offering-users-the-option-to-forget-their-get-an-identity-email