### PR TITLE
Handle existing but different email situation

### DIFF
--- a/app/data.js
+++ b/app/data.js
@@ -24,6 +24,11 @@ export default {
       name: 'Get an identity: Show the No match page',
       description: 'Include the ‘no match’ page in the journey'
     },
+    replacingEmail: {
+      on: false,
+      name: 'Get an identity: Existing email doest not match',
+      description: 'Test the journey when a user matches an existing account but they used a different email address'
+    },
     apiUnavailable: {
       on: false,
       name: 'Find: API unavailable',

--- a/app/routes/support.js
+++ b/app/routes/support.js
@@ -1,4 +1,5 @@
 import supportNameChangeWizard from '../wizards/support-name-change-wizard.js'
+import supportEmailChangeWizard from '../wizards/support-email-change-wizard.js'
 import supportDQTLinkWizard from '../wizards/support-dqt-link-wizard.js'
 
 export const supportRoutes = router => {
@@ -16,6 +17,11 @@ export const supportRoutes = router => {
 
   router.all(['/support/:user/name-change', '/support/:user/name-change/*'], (req, res, next) => {
     res.locals.paths = supportNameChangeWizard(req, res)
+    next()
+  })
+
+  router.all(['/support/:user/email-change', '/support/:user/email-change/*'], (req, res, next) => {
+    res.locals.paths = supportEmailChangeWizard(req, res)
     next()
   })
 
@@ -37,6 +43,9 @@ export const supportRoutes = router => {
       switch (req.query.success) {
         case 'name-change':
           res.locals.appSuccess = { heading: 'Name changed successfully' }
+          break
+        case 'email-change':
+          res.locals.appSuccess = { heading: 'Email changed successfully' }
           break
         case 'dqt-linked':
           res.locals.appSuccess = { heading: 'DQT record added' }

--- a/app/views/get-an-identity/different-email-cannot-access.html
+++ b/app/views/get-an-identity/different-email-cannot-access.html
@@ -1,0 +1,10 @@
+{% extends "layouts/wizard.html" %}
+{% set title = "A support agent will be in touch" %}
+{% set hideButton = true %}
+
+{% block form %}
+<h1 class="govuk-heading-xl">{{ title | noOrphans | safe }}</h1>
+
+<p>You’ve told us you cannot access the email address we have on record, a support agent will be in touch to help you get access to your account.</p>
+
+{% endblock %}

--- a/app/views/get-an-identity/different-email-cannot-access.html
+++ b/app/views/get-an-identity/different-email-cannot-access.html
@@ -16,7 +16,7 @@
 
 <p>To send a secure email to the Teaching Regulation Agency (TRA) you need to use the Galaxkey site:<br />
 
-<p><a href="#">https://manager.galaxkey.com/services/registerme</a></p>
+<p><a href="https://manager.galaxkey.com/services/registerme">https://manager.galaxkey.com/services/registerme</a></p>
 
 <p>Use your new email address, jane.doe@example.com.</p>
 
@@ -28,8 +28,8 @@
 
 <ul class="govuk-list govuk-list--bullet">
   <li>select ‘Compose’ to create a new secure email</li>
-  <li>enter ‘’ as the recipient</li>
-  <li>enter ‘’ as the subject line</li>
+  <li>enter ‘[TO BE DETERMINED]’ as the recipient</li>
+  <li>enter ‘[TO BE DETERMINED]’ as the subject line</li>
   <li>in your email include:
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-2">
       <li>your full legal name</li>

--- a/app/views/get-an-identity/different-email-cannot-access.html
+++ b/app/views/get-an-identity/different-email-cannot-access.html
@@ -1,10 +1,55 @@
 {% extends "layouts/wizard.html" %}
-{% set title = "A support agent will be in touch" %}
+{% set title = "You need to prove your identity to change your email address" %}
 {% set hideButton = true %}
 
 {% block form %}
 <h1 class="govuk-heading-xl">{{ title | noOrphans | safe }}</h1>
 
-<p>You’ve told us you cannot access the email address we have on record, a support agent will be in touch to help you get access to your account.</p>
+<p>Call the Teaching Regulation Agency (TRA) for support.</p>
 
+<p>
+  Telephone: 020 7593 5394<br />
+  Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)
+</p>
+
+<h2 class="govuk-heading-m">Send a secure email using Galaxkey</h2>
+
+<p>To send a secure email to the Teaching Regulation Agency (TRA) you need to use the Galaxkey site:<br />
+
+<p><a href="#">https://manager.galaxkey.com/services/registerme</a></p>
+
+<p>Use your new email address, jane.doe@example.com.</p>
+
+<p>After you activate your account you can then send secure emails to TRA using Galaxkey.</p>
+
+<h2 class="govuk-heading-m">Send your ID documents securely</h2>
+
+<p>Follow these steps to send your documents through Galaxkey:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>select ‘Compose’ to create a new secure email</li>
+  <li>enter ‘’ as the recipient</li>
+  <li>enter ‘’ as the subject line</li>
+  <li>in your email include:
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-2">
+      <li>your full legal name</li>
+      <li>your date of birth</li>
+      <li>your email address</li>
+    </ul>
+  </li>
+  <li>attach a scanned copy or photo of one of the following types of ID:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>passport</li>
+      <li>driving licence (full or provisional)</li>
+      <li>certificate of residence</li>
+      <li>birth certificate</li>
+    </ul>
+  </li>
+</ul>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p>TRA will confirm your identity and update your email address.</p>
+
+<p>Your ID documents will be deleted once your request is processed.</p>
 {% endblock %}

--- a/app/views/get-an-identity/different-email.html
+++ b/app/views/get-an-identity/different-email.html
@@ -1,0 +1,53 @@
+{% extends "layouts/wizard.html" %}
+{% set title = 'Your email address is different to the one on record' %}
+{% set hideButton = true %}
+
+{% block form %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+
+  <p>It might be because you’ve used this service before, and you are:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>using a different personal or work email address</li>
+    <li>using a new work email address</li>
+  </ul>
+
+  <h2 class="govuk-heading-m">Confirm your email address to continue</h2>
+
+  <p>We’ve sent a confirmation code to:</p>
+  <div class="govuk-inset-text">
+    j***@***.sch.uk
+  </div>
+
+  {{ govukInput({
+    label: {
+      text: "Enter your code",
+      classes: "govuk-label--s"
+    },
+    classes: 'govuk-!-width-one-quarter',
+    decorate: 'identity.email-code'
+  }) }}
+
+  {{ govukButton({
+    html: buttonText if buttonText else 'Continue'
+  }) }}
+
+  <h2 class="govuk-heading-m">Help if you cannot confirm this email address</h2>
+
+  <ul class="govuk-list">
+    <li><a href="#">I do not recognise this email address</a></li>
+    <li><a href="#">I cannot access this email address</a></li>
+    <li><a href="#">I have not received an email</a></li>
+  </ul>
+
+  <p>
+
+  </p>
+
+  <p>
+
+  </p>
+
+  <p>
+
+  </p>
+{% endblock %}

--- a/app/views/get-an-identity/different-email.html
+++ b/app/views/get-an-identity/different-email.html
@@ -34,8 +34,8 @@
   <h2 class="govuk-heading-m">Help if you cannot confirm this email address</h2>
 
   <ul class="govuk-list">
-    <li><a href="#">I do not recognise this email address</a></li>
-    <li><a href="#">I cannot access this email address</a></li>
+    <li><a href="/get-an-identity/different-email-not-recognise">I do not recognise this email address</a></li>
+    <li><a href="/get-an-identity/different-email-cannot-access">I cannot access this email address</a></li>
     <li><a href="#">I have not received an email</a></li>
   </ul>
 

--- a/app/views/get-an-identity/different-email.html
+++ b/app/views/get-an-identity/different-email.html
@@ -5,7 +5,7 @@
 {% block form %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-  <p>It might be because you’ve used this service before, and you are:</p>
+  <p>This could be because you’ve used this service before, and you are:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>using a different personal or work email address</li>
     <li>using a new work email address</li>

--- a/app/views/get-an-identity/different-email.html
+++ b/app/views/get-an-identity/different-email.html
@@ -34,20 +34,8 @@
   <h2 class="govuk-heading-m">Help if you cannot confirm this email address</h2>
 
   <ul class="govuk-list">
-    <li><a href="/get-an-identity/different-email-not-recognise">I do not recognise this email address</a></li>
+    <li><a href="/get-an-identity/different-email-cannot-access">I do not recognise this email address</a></li>
     <li><a href="/get-an-identity/different-email-cannot-access">I cannot access this email address</a></li>
     <li><a href="#">I have not received an email</a></li>
   </ul>
-
-  <p>
-
-  </p>
-
-  <p>
-
-  </p>
-
-  <p>
-
-  </p>
 {% endblock %}

--- a/app/views/get-an-identity/finish.html
+++ b/app/views/get-an-identity/finish.html
@@ -13,7 +13,7 @@
   {% endif %}
 
   <h2 class="govuk-heading-m">Next time</h2>
-  <p class="govuk-!-margin-bottom-6">Next time, you can skip these questions by signing in with your email address: <b>{{ data['email-address'] or "email@example.com" }}</b></p>
+  <p class="govuk-!-margin-bottom-6">Next time, you can skip these questions by signing in with your email address: <b>{{ data['replaced-email-address'] or data['email-address'] or "email@example.com" }}</b></p>
 
   <input type="hidden" name="account-data" value="{{ data | stringify }}">
 {% endblock %}

--- a/app/views/get-an-identity/replace-email.html
+++ b/app/views/get-an-identity/replace-email.html
@@ -1,0 +1,25 @@
+{% extends "layouts/wizard.html" %}
+{% set title = 'Which email address do you want to use?' %}
+
+{% block form %}
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-6",
+        isPageHeading: true,
+        text: title
+      }
+    },
+    items: [{
+      text: d('email') or 'jane.doe@example.com'
+    }, {
+      text: 'jane.doe@st-marys.sch.uk'
+    }],
+    decorate: "identity.do-you-know-your-trn",
+    validate: {
+      presence: {
+        message: "Tell us if you know your TRN"
+      }
+    }
+  }) }}
+{% endblock %}

--- a/app/views/get-an-identity/replace-email.html
+++ b/app/views/get-an-identity/replace-email.html
@@ -15,7 +15,7 @@
     }, {
       text: 'jane.doe@st-marys.sch.uk'
     }],
-    decorate: "identity.do-you-know-your-trn",
+    decorate: "replaced-email-address",
     validate: {
       presence: {
         message: "Tell us if you know your TRN"

--- a/app/views/support/email-change/email.html
+++ b/app/views/support/email-change/email.html
@@ -1,0 +1,14 @@
+{% extends "layouts/wizard.html" %}
+{% set title = "Change email address" %}
+{% set buttonText = "Save" %}
+
+{% block form %}
+  {{ govukInput({
+    label: {
+      text: title,
+      classes: "govuk-label--xl",
+      isPageHeading: true
+    },
+    decorate: dataPath + '.email'
+  }) }}
+{% endblock %}

--- a/app/views/support/user.html
+++ b/app/views/support/user.html
@@ -72,7 +72,7 @@
         value: {
           html: user.email
         },
-        href: '#'
+        href: urlPath + '/email-change/email'
       },
       {
         key: 'DQT record',

--- a/app/wizards/get-an-identity.js
+++ b/app/wizards/get-an-identity.js
@@ -10,6 +10,7 @@ export default (req) => {
   const trnRequired = data.features.trnRequired.on
   const hasTrn = (data.identity && data.identity['do-you-have-a-trn'] === 'Yes') || trnRequired
   const noMatchJourney = data.features.noMatchJourney.on
+  const replacingEmail = true
 
   const journey = {
     '/get-an-identity/email': {},
@@ -54,6 +55,12 @@ export default (req) => {
         '/get-an-identity/no-match': {
           '/get-an-identity/check-answers': { data: 'identity.try-again', value: 'yes' }
         }
+      }
+      : {},
+    ...(replacingEmail)
+      ? {
+        '/get-an-identity/different-email': {},
+        '/get-an-identity/replace-email': {}
       }
       : {},
     '/get-an-identity/finish': {},

--- a/app/wizards/get-an-identity.js
+++ b/app/wizards/get-an-identity.js
@@ -10,7 +10,7 @@ export default (req) => {
   const trnRequired = data.features.trnRequired.on
   const hasTrn = (data.identity && data.identity['do-you-have-a-trn'] === 'Yes') || trnRequired
   const noMatchJourney = data.features.noMatchJourney.on
-  const replacingEmail = true
+  const replacingEmail = data.features.replacingEmail.on
 
   const journey = {
     '/get-an-identity/email': {},

--- a/app/wizards/support-email-change-wizard.js
+++ b/app/wizards/support-email-change-wizard.js
@@ -1,0 +1,13 @@
+import { wizard } from 'govuk-prototype-rig'
+
+export default (req, res) => {
+  const userId = req.params.user
+  const basePath = `/support/${userId}`
+  const journey = {
+    [basePath]: {},
+    [`${basePath}/email-change/email`]: {},
+    [`${basePath}?success=email-change`]: {}
+  }
+
+  return wizard(journey, req)
+}


### PR DESCRIPTION
## If you used an email address we do not recognise, but your details match a record

This shows _after_ the check your answers page. You can test this journey using the feature flag 'Get an identity: Existing email doest not match'.

If they can access their old email address, and they continue, we ask which they want to use going forward.

![localhost_3001_get-an-identity_different-email](https://user-images.githubusercontent.com/319055/190656678-2780d484-00f4-4a33-acbc-5175992b3683.png)

## If you cannot access your old email address

![localhost_3001_get-an-identity_different-email-cannot-access (1)](https://user-images.githubusercontent.com/319055/190656671-7496cb61-5351-471e-b141-1491b81bc42f.png)
