### PR TITLE
Specify a max Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.0.0 <17"
   },
   "prototype": {
     "serviceName": "Find a lost teacher reference number (TRN)",


### PR DESCRIPTION
This should fix the deployment pipeline.

It's currently failing because there is a new version of Node v19 that might be breaking the Sass compiler.